### PR TITLE
Option “-e” is deprecated and might be removed in a later version of gnome-terminal.

### DIFF
--- a/C Builder-Minghang Yang.sublime-build
+++ b/C Builder-Minghang Yang.sublime-build
@@ -15,7 +15,7 @@
         "name": "Run",
         "shell": true,
         "linux": {
-            "cmd": ["gnome-terminal -e 'bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\"'"]
+            "cmd": ["gnome-terminal -- bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\""]
         },
         "osx": {
             "shell_cmd": "echo 'cd \"${file_path}/\"' > '/tmp/${file_base_name}' && echo './\"${file_base_name}\"' >> '/tmp/${file_base_name}' && echo read >> '/tmp/${file_base_name}' && chmod +x '/tmp/${file_base_name}' && open -a Terminal.app '/tmp/${file_base_name}'"
@@ -28,7 +28,7 @@
         "name": "Build and Run",
         "shell": true,
         "linux": {
-            "cmd": ["gcc -std=c11 \"${file}\" -o \"${file_base_name}\" && gnome-terminal -e 'bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\"'"]
+            "cmd": ["gcc -std=c11 \"${file}\" -o \"${file_base_name}\" && gnome-terminal -- bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\""]
         },
         "windows": {
             "shell_cmd": "gcc -std=c11 \"${file}\" -o \"${file_base_name}.exe\" && start cmd /c \"\"${file_base_name}.exe\" & echo. & pause\""

--- a/C++ Builder-Minghang Yang.sublime-build
+++ b/C++ Builder-Minghang Yang.sublime-build
@@ -15,7 +15,7 @@
         "name": "Run",
         "shell": true,
         "linux": {
-            "cmd": ["gnome-terminal -e 'bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\"'"]
+            "cmd": ["gnome-terminal -- bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\""]
         },
         "osx": {
             "shell_cmd": "echo 'cd \"${file_path}/\"' > '/tmp/${file_base_name}' && echo './\"${file_base_name}\"' >> '/tmp/${file_base_name}' && echo read >> '/tmp/${file_base_name}' && chmod +x '/tmp/${file_base_name}' && open -a Terminal.app '/tmp/${file_base_name}'"
@@ -28,7 +28,7 @@
         "name": "Build and Run",
         "shell": true,
         "linux": {
-            "cmd": ["g++ -std=c++11 \"${file}\" -o \"${file_base_name}\" && gnome-terminal -e 'bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\"'"]
+            "cmd": ["g++ -std=c++11 \"${file}\" -o \"${file_base_name}\" && gnome-terminal -- bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\""]
         },
         "windows": {
             "shell_cmd": "g++ -std=c++11 \"${file}\" -o \"${file_base_name}.exe\" && start cmd /c \"\"${file_base_name}.exe\" & echo. & pause\""


### PR DESCRIPTION
Each time I build and run a CPP or C file I got two messages in my Sublime Text 3 panel:

```
# Option “-e” is deprecated and might be removed in a later version of gnome-terminal.
# Use “-- ” to terminate the options and put the command line to execute after it.
```

I modified the C++ and C bash file. Now no panel messages are received and it works fine. Please review.

PS: I am currently using Ubuntu 18.04 LTS. 
And thanks for providing this package.